### PR TITLE
Fixes bug where echo remains off when player quits

### DIFF
--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -427,7 +427,7 @@ class OMXPlayer(object):
     def quit(self):
         logger.debug('Quitting OMXPlayer')
         try:
-            os.killpg(self._process.pid, signal.SIGTERM)
+            os.killpg(self._process.pid, signal.SIGINT)
             self._process.wait()
             self._process_monitor.join()
             logger.debug('SIGTERM Sent to pid: %s' % self._process.pid)

--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -430,7 +430,7 @@ class OMXPlayer(object):
             os.killpg(self._process.pid, signal.SIGINT)
             self._process.wait()
             self._process_monitor.join()
-            logger.debug('SIGTERM Sent to pid: %s' % self._process.pid)
+            logger.debug('SIGINT Sent to pid: %s' % self._process.pid)
         except OSError:
             logger.error('Could not find the process to kill')
 

--- a/tests/test_omxplayer.py
+++ b/tests/test_omxplayer.py
@@ -89,7 +89,7 @@ class OMXPlayerTests(unittest.TestCase):
         popen.return_value = omxplayer_process
         self.patch_and_run_omxplayer()
         self.player.quit()
-        killpg.assert_called_once_with(omxplayer_process.pid, signal.SIGTERM)
+        killpg.assert_called_once_with(omxplayer_process.pid, signal.SIGINT)
 
     def test_quitting_waits_for_omxplayer_to_die(self, popen, sleep, isfile, killpg, *args):
         omxplayer_process = Mock()


### PR DESCRIPTION
Changed how the omxplayer is quit. This solves the freezing console bug where echo on the terminal stayed off when the player was issued a SIGTERM.
Instead of issuing a SIGTERM it is now issuing a SIGINT which turns echo back on. 
